### PR TITLE
Add multi-account token storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,12 @@ go run .
 
 ### Session handling
 
-`Login` saves the JWT token to `~/.moneylover-client`. Load it on the next run
-with `LoadToken` and only log in again when the saved session is invalid:
+`Login` saves the JWT token to `~/.moneylover-client` keyed by your email
+address. Load it on the next run with `LoadTokenForUser("email")` and only log
+in again when the saved session is invalid:
 
 ```go
-token, err := ml.LoadToken()
+token, err := ml.LoadTokenForUser("tamvan@dika.web.id")
 var client *ml.Client
 if err == nil && token != "" {
     client = ml.NewClient(token)
@@ -69,6 +70,10 @@ if err == nil && token != "" {
     client, err = ml.Login("tamvan@dika.web.id", "password")
 }
 ```
+
+Use `SaveTokenForUser(email, token)` to store sessions for additional accounts
+and `LoadTokenForUser(email)` to restore them later. Call `TokenExpired(token)`
+to check whether a stored JWT is still valid before hitting the API.
 
 ### ID placeholders
 

--- a/commands.go
+++ b/commands.go
@@ -6,7 +6,7 @@ func Login(email, password string) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := SaveToken(token); err != nil {
+	if err := SaveTokenForUser(email, token); err != nil {
 		return nil, err
 	}
 	return NewClient(token), nil

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package moneylover
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 )
@@ -14,7 +15,59 @@ func configFile() string {
 
 // SaveToken stores the JWT token in the config file.
 func SaveToken(token string) error {
-	cfg := map[string]string{"jwtToken": token}
+	return SaveTokenForUser("jwtToken", token)
+}
+
+// SaveTokenForUser stores the JWT token for the given email.
+func SaveTokenForUser(email, token string) error {
+	cfg, err := readTokenMap()
+	if err != nil {
+		return err
+	}
+	cfg[email] = token
+	return writeTokenMap(cfg)
+}
+
+// LoadToken reads the stored JWT token from the config file.
+func LoadToken() (string, error) {
+	return LoadTokenForUser("jwtToken")
+}
+
+// LoadTokenForUser reads the stored JWT token for the given email.
+func LoadTokenForUser(email string) (string, error) {
+	cfg, err := readTokenMap()
+	if err != nil {
+		return "", err
+	}
+	tok, ok := cfg[email]
+	if !ok {
+		return "", errors.New("token not found")
+	}
+	return tok, nil
+}
+
+// ClearToken removes the config file.
+func ClearToken() error {
+	return ClearTokenForUser("jwtToken")
+}
+
+func readTokenMap() (map[string]string, error) {
+	f, err := os.Open(configFile())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]string{}, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+	var cfg map[string]string
+	if err := json.NewDecoder(f).Decode(&cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func writeTokenMap(cfg map[string]string) error {
 	f, err := os.Create(configFile())
 	if err != nil {
 		return err
@@ -23,21 +76,18 @@ func SaveToken(token string) error {
 	return json.NewEncoder(f).Encode(cfg)
 }
 
-// LoadToken reads the stored JWT token from the config file.
-func LoadToken() (string, error) {
-	f, err := os.Open(configFile())
+// ClearTokenForUser removes the stored token for the given email.
+func ClearTokenForUser(email string) error {
+	cfg, err := readTokenMap()
 	if err != nil {
-		return "", err
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
 	}
-	defer f.Close()
-	var cfg map[string]string
-	if err := json.NewDecoder(f).Decode(&cfg); err != nil {
-		return "", err
+	delete(cfg, email)
+	if len(cfg) == 0 {
+		return os.Remove(configFile())
 	}
-	return cfg["jwtToken"], nil
-}
-
-// ClearToken removes the config file.
-func ClearToken() error {
-	return os.Remove(configFile())
+	return writeTokenMap(cfg)
 }

--- a/sample/main.go
+++ b/sample/main.go
@@ -9,16 +9,20 @@ import (
 )
 
 func main() {
-	// try to load a saved session
-	token, err := moneylover.LoadToken()
+	// try to load a saved session for a specific email
+	token, err := moneylover.LoadTokenForUser("email@example.com")
 	var client *moneylover.Client
 	if err == nil && token != "" {
-		client = moneylover.NewClient(token)
-		if _, err = client.GetUserInfo(); err == nil {
-			fmt.Println("loaded existing session")
+		if expired, _ := moneylover.TokenExpired(token); !expired {
+			client = moneylover.NewClient(token)
+			if _, err = client.GetUserInfo(); err == nil {
+				fmt.Println("loaded existing session")
+			} else {
+				fmt.Println("stored session invalid, logging in again")
+				client = nil
+			}
 		} else {
 			fmt.Println("stored session expired, logging in again")
-			client = nil
 		}
 	}
 	if client == nil {

--- a/token.go
+++ b/token.go
@@ -1,0 +1,31 @@
+package moneylover
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
+
+// TokenExpired returns true if the given JWT token is expired based on its `exp` claim.
+func TokenExpired(token string) (bool, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return false, errors.New("invalid token")
+	}
+	payload, err := base64.RawStdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return false, err
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return false, err
+	}
+	if claims.Exp == 0 {
+		return false, errors.New("exp not found")
+	}
+	return time.Now().Unix() > claims.Exp, nil
+}


### PR DESCRIPTION
## Summary
- support saving JWT tokens by email
- add helpers to load and clear token per user
- document session management for multiple accounts
- update sample code to demonstrate `LoadTokenForUser`
- check token expiry with new `TokenExpired` helper

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_6869249a6b5c832699e8688776691b36